### PR TITLE
Added CSS styles for new Ghost bookmark card feature

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1147,7 +1147,16 @@ ul.post-archive{margin-left:0!important;}
 
 .kg-bookmark-title {
 	font-weight: 600;
-	font-size: 1rem;
+	font-size: 1.2rem;
+	line-height:1.5em;
+	font-family: 'Montserrat',
+				 -apple-system,
+				 BlinkMacSystemFont,
+				 "PingFang SC",
+				 "Heiti SC", 
+				 "STXihei", 
+				 "Microsoft YaHei",
+				 sans-serif;
 }
 
 .kg-bookmark-description,

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1116,3 +1116,65 @@ ul.post-archive{margin-left:0!important;}
 .error-wrap .message-manual {
     margin-bottom: 32px;
 }
+
+/* ====================== bookmark card ====================== 2019.09.07 */
+.kg-bookmark-container {
+	display: flex;
+	flex-wrap: wrap;
+	color: black;
+	text-decoration: none;
+	margin: 0;
+	border-radius: 5px;
+	overflow: hidden;
+	border: 1px solid #e5eff5 !important;
+	box-shadow: 0 0 1px rgba(0,0,0,.06),0 2px 6px rgba(0,0,0,.03);
+}
+
+.kg-bookmark-card a:hover {
+	color: black !important;
+}
+
+
+.kg-bookmark-content {    
+	flex-basis: 0;
+	flex-grow: 999;
+	min-width: 50%;
+	padding: 20px;
+	font-size: 1rem;
+	line-height: 1;
+	text-align: left;
+}
+
+.kg-bookmark-title {
+	font-weight: 600;
+	font-size: 1rem;
+}
+
+.kg-bookmark-description,
+.kg-bookmark-metadata {
+	margin-top: 12px;
+}
+
+.kg-bookmark-thumbnail {
+	flex-basis: 15rem;
+	flex-grow: 1;
+}
+
+
+.kg-bookmark-thumbnail img {
+	vertical-align: bottom;
+	object-fit: cover;
+	width: 100%;
+}
+
+.kg-bookmark-icon {
+	width: 22px;
+	height: 22px;
+	margin-right: 8px;
+	vertical-align: bottom;
+}
+
+.kg-bookmark-author:after {
+	content: "•";
+	margin: 0 6px;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1163,7 +1163,10 @@ ul.post-archive{margin-left:0!important;}
 }
 .kg-bookmark-description,
 .kg-bookmark-metadata {
-	margin-top: 12px;
+	margin-top: .5em;
+	line-height:1.5em;
+	max-height: 3em;
+	overflow-y: hidden;
 }
 
 .kg-bookmark-thumbnail {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1158,7 +1158,9 @@ ul.post-archive{margin-left:0!important;}
 				 "Microsoft YaHei",
 				 sans-serif;
 }
-
+.kg-bookmark-description{ 
+	color: #666;
+}
 .kg-bookmark-description,
 .kg-bookmark-metadata {
 	margin-top: 12px;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1182,6 +1182,14 @@ ul.post-archive{margin-left:0!important;}
 	vertical-align: bottom;
 	object-fit: cover;
 	width: 100%;
+	height:100%; 
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0 3px 3px 0;
 }
 
 .kg-bookmark-icon {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1172,6 +1172,9 @@ ul.post-archive{margin-left:0!important;}
 .kg-bookmark-thumbnail {
 	flex-basis: 15rem;
 	flex-grow: 1;
+    position: relative; 
+    min-width: 33%; 
+    max-height: 100%;
 }
 
 


### PR DESCRIPTION
Hi, I've added some CSS to style the newly introduced bookmark card feature.

See [https://ghost.org/blog/new-bookmark-cards/](https://ghost.org/blog/new-bookmark-cards/) for some documentation relating to this feature.

The documentation has the minimum CSS styles required for the feature, but I've made some tweaks to override the font sizing, line height and also the link hover styles (dotted underline and colour change on hover).