### PR TITLE
Static Page: Site Authors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
     "name": "fizzy",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "fizzy",
     "description": "A tasty blogging theme for Ghost.",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "author": {
         "name": "Yuzhang Huang",
         "email": "huangyuzhang@live.cn"


### PR DESCRIPTION
displays all blog authors on /authors page.
for example of this in action, please see: https://squintermedia.com/authors/

(re-submission to dev branch)