### PR TITLE
Don't show the search btn on scroll if disabled

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -105,7 +105,9 @@ $(document).mouseup(function(e)
 $(window).scroll(function(){
   $("#search-form").hide(); 
   $("#search-results").hide(); 
-  $("#search-btn").show();
+  if (show_search) {
+    $("#search-btn").show();
+  }
 });
 
 /*----------------------------------------------------*/


### PR DESCRIPTION
If `show_search === false`, scrolling on any page makes the search button visible. This quick patch adds a guard to check `show_search` and respond accordingly.